### PR TITLE
Basic iteration/debugging

### DIFF
--- a/app/controllers/echo_controller.rb
+++ b/app/controllers/echo_controller.rb
@@ -1,5 +1,9 @@
 class EchoController < ApplicationController
   def index
-    render json: { message: params[:message] }
+    render json: {
+      message: params[:message],
+      secret: Rails.application.secrets.some_other_secret,
+      database: Rails.application.config.database_configuration['development']['some_other_config']
+    }
   end
 end

--- a/app/controllers/echo_controller.rb
+++ b/app/controllers/echo_controller.rb
@@ -6,4 +6,9 @@ class EchoController < ApplicationController
       database: Rails.application.config.database_configuration['development']['some_other_config']
     }
   end
+
+  def debug
+    byebug
+    render json: {}
+  end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -12,6 +12,7 @@ default: &default
 development:
   <<: *default
   database: db/development.sqlite3
+  some_other_config: its a db config
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".

--- a/config/initializers/byebug.rb
+++ b/config/initializers/byebug.rb
@@ -1,5 +1,4 @@
 if Rails.env.development?
-  print "I'm in byebug.rb"
   require 'byebug/core'
   #Byebug.wait_connection = true
   Byebug.start_server 'localhost', ENV.fetch("BYEBUG_SERVER_PORT", 9876).to_i rescue nil

--- a/config/initializers/byebug.rb
+++ b/config/initializers/byebug.rb
@@ -1,0 +1,6 @@
+if Rails.env.development?
+  print "I'm in byebug.rb"
+  require 'byebug/core'
+  #Byebug.wait_connection = true
+  Byebug.start_server 'localhost', ENV.fetch("BYEBUG_SERVER_PORT", 9876).to_i rescue nil
+end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -21,7 +21,7 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
@@ -30,15 +30,15 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # you need to make sure to reconnect any threads in the `on_worker_boot`
 # block.
 #
-# preload_app!
+preload_app!
 
 # If you are preloading your application and using Active Record, it's
 # recommended that you close any connections to the database before workers
 # are forked to prevent connection leakage.
 #
-# before_fork do
-#   ActiveRecord::Base.connection_pool.disconnect! if defined?(ActiveRecord)
-# end
+ before_fork do
+   ActiveRecord::Base.connection_pool.disconnect! if defined?(ActiveRecord)
+ end
 
 # The code in the `on_worker_boot` will be called if you are using
 # clustered mode by specifying a number of `workers`. After each worker
@@ -47,10 +47,10 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # or connections that may have been created at application boot, as Ruby
 # cannot share connections between processes.
 #
-# on_worker_boot do
-#   ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
-# end
-#
+on_worker_boot do
+  ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
+end
+
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   resources :echo, only: [:index]
+  get 'debug', to: 'echo#debug'
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -19,7 +19,7 @@
 
 development:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
-  some_other_secret: <%= ENV["SOME_OTHER_SECRET"] %>
+  some_other_secret: hard coded secret
 
 test:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -19,6 +19,7 @@
 
 development:
   secret_key_base: 39442fb448c0059e9a7ef1bc39c8b9b8411cac2cb2a5a28ec6cfd071508335ee1dd88520b323ee06fa19c07c23510503ea203bfe8ce165200e7f72030bad8c6d
+  some_other_secret: "it's a secret to everyone"
 
 test:
   secret_key_base: a911f12e5777344240bed54b959c8af853cb7a1b0544f62d55d1289dea5701f8cf8d3e7e41825de44f810973ee7d27e7858945ba6dd32fbd16013bb901e27bb9

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -18,11 +18,11 @@
 # Environmental secrets are only available for that specific environment.
 
 development:
-  secret_key_base: 39442fb448c0059e9a7ef1bc39c8b9b8411cac2cb2a5a28ec6cfd071508335ee1dd88520b323ee06fa19c07c23510503ea203bfe8ce165200e7f72030bad8c6d
-  some_other_secret: "it's a secret to everyone"
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  some_other_secret: <%= ENV["SOME_OTHER_SECRET"] %>
 
 test:
-  secret_key_base: a911f12e5777344240bed54b959c8af853cb7a1b0544f62d55d1289dea5701f8cf8d3e7e41825de44f810973ee7d27e7858945ba6dd32fbd16013bb901e27bb9
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
 
 # Do not keep production secrets in the unencrypted secrets file.
 # Instead, either read values from the environment.


### PR DESCRIPTION
All of these are changes to the app that are associated with basic iteration, including remote debugging, inside of openshift/containers. Key points:
- Secrets are best to keep in env variables, even for the dev environment.
- Files that rails will dynamically reload can be sufficiently iterated on using `oc rsync . {pod-name}:/opt/app-root/src --no-perms=true --watch`
- Files that rails will not dynamically reload, such as secrets.yml, or those that require a rebuild/restart, such as Gemfile, can be iterated on by rebuilding from local: `oc start-build {build-name} --from-dir=.`
- Remote debugging with byebug works, as long as:
  1. You ensure rails is run in dev environment
  1. Puma does not start with any worker processes
  1. You forward the port from your client to the pod: `oc port-forward {pod-name} 9876:9876`
